### PR TITLE
update tags/list location regex to allow any image name instead of xx/yy

### DIFF
--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -108,7 +108,7 @@ http {
       proxy_cache_lock       on;
     }
 
-    location ~ ^/v2/.*/.*/tags/list+$ {
+    location ~ ^/v2/.*(/.*)*/tags/list+$ {
       # get paginated list of tags
       content_by_lua_block {
         local location, tags, cjson = ngx.var.uri, {}, require "cjson"


### PR DESCRIPTION
Current location regex only allows for image names that follow an `xx/yy` name pattern. Switching regex allows for multiple levels of name hierarchy (i.e. `xx`, `xx/yy`, `xx/yy/zz`) to aid in compatibility with legacy registries that don't follow best-practice naming conventions. 
