### PR TITLE
fix: AWS ECR token too long cause nginx emerg error

### DIFF
--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -18,7 +18,7 @@ http {
   # this is necessary for us to be able to disable request buffering in all cases
   proxy_http_version 1.1;
 
-  lua_shared_dict token_dict 5m;
+  lua_shared_dict token_dict 1m;
 
   # will run before forking out nginx worker processes
   init_by_lua_block {
@@ -29,6 +29,8 @@ http {
         local data = token_file:read()
         ngx.shared.token_dict:set("ecr_token", data)
         token_file:close()
+    else
+        ngx.log(ngx.ERR, "Failed to open token file: /usr/local/openresty/nginx/token.txt")
     end
   }
 

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -18,8 +18,19 @@ http {
   # this is necessary for us to be able to disable request buffering in all cases
   proxy_http_version 1.1;
 
+  lua_shared_dict token_dict 5m;
+
   # will run before forking out nginx worker processes
-  init_by_lua_block { require "cjson" }
+  init_by_lua_block {
+    require "cjson"
+
+    local token_file = io.open('/usr/local/openresty/nginx/token.txt', 'r')
+    if token_file then
+        local data = token_file:read()
+        ngx.shared.token_dict:set("ecr_token", data)
+        token_file:close()
+    end
+  }
 
   #https://docs.docker.com/registry/recipes/nginx/#setting-things-up
   map $upstream_http_docker_distribution_api_version $docker_distribution_api_version {
@@ -28,6 +39,10 @@ http {
 
   server {
     listen PORT SSL_LISTEN default_server;
+
+    set_by_lua_block $http_authorization {
+        return ngx.shared.token_dict:get("ecr_token")
+    }
 
     SSL_INCLUDE
 

--- a/files/renew_token.sh
+++ b/files/renew_token.sh
@@ -6,7 +6,7 @@ set -xe
 CONFIG=/usr/local/openresty/nginx/conf/nginx.conf
 AUTH=$(grep  X-Forwarded-User $CONFIG | awk '{print $4}'| uniq|tr -d "\n\r")
 
-set +x
+
 # retry till new get new token
 while true; do
   TOKEN=$(aws ecr get-authorization-token --query 'authorizationData[*].authorizationToken' --output text)
@@ -15,6 +15,7 @@ while true; do
   sleep 30
 done
 
+set +x
 echo $TOKEN > /usr/local/openresty/nginx/token.txt
 set -x
 

--- a/files/renew_token.sh
+++ b/files/renew_token.sh
@@ -6,6 +6,7 @@ set -xe
 CONFIG=/usr/local/openresty/nginx/conf/nginx.conf
 AUTH=$(grep  X-Forwarded-User $CONFIG | awk '{print $4}'| uniq|tr -d "\n\r")
 
+set +x
 # retry till new get new token
 while true; do
   TOKEN=$(aws ecr get-login --no-include-email | awk '{print $6}')
@@ -17,6 +18,7 @@ done
 
 AUTH_N=$(echo AWS:${TOKEN}  | base64 |tr -d "[:space:]")
 
-sed -i "s|${AUTH%??}|${AUTH_N}|g" $CONFIG
+echo $AUTH_N > /usr/local/openresty/nginx/token.txt
+set -x
 
 nginx -s reload

--- a/files/renew_token.sh
+++ b/files/renew_token.sh
@@ -9,16 +9,13 @@ AUTH=$(grep  X-Forwarded-User $CONFIG | awk '{print $4}'| uniq|tr -d "\n\r")
 set +x
 # retry till new get new token
 while true; do
-  TOKEN=$(aws ecr get-login --no-include-email | awk '{print $6}')
+  TOKEN=$(aws ecr get-authorization-token --query 'authorizationData[*].authorizationToken' --output text)
   [ ! -z "${TOKEN}" ] && break
   echo "Warn: Unable to get new token, wait and retry!"
   sleep 30
 done
 
-
-AUTH_N=$(echo AWS:${TOKEN}  | base64 |tr -d "[:space:]")
-
-echo $AUTH_N > /usr/local/openresty/nginx/token.txt
+echo $TOKEN > /usr/local/openresty/nginx/token.txt
 set -x
 
 nginx -s reload

--- a/files/startup.sh
+++ b/files/startup.sh
@@ -80,9 +80,9 @@ chmod 600 -R ${AWS_FOLDER}
 set +x
 # add the auth token in default.conf
 AUTH=$(grep  X-Forwarded-User $CONFIG | awk '{print $4}'| uniq|tr -d "\n\r")
-TOKEN=$(aws ecr get-login --no-include-email | awk '{print $6}')
-AUTH_N=$(echo AWS:${TOKEN}  | base64 |tr -d "[:space:]")
-echo $AUTH_N > /usr/local/openresty/nginx/token.txt
+TOKEN=$(aws ecr get-authorization-token --query 'authorizationData[*].authorizationToken' --output text)
+
+echo $TOKEN > /usr/local/openresty/nginx/token.txt
 
 set -x
 # make sure cache directory has correct ownership

--- a/files/startup.sh
+++ b/files/startup.sh
@@ -77,12 +77,14 @@ if [ -z "$AWS_USE_EC2_ROLE_FOR_AUTH" ] || [ "$AWS_USE_EC2_ROLE_FOR_AUTH" != "tru
 fi
 chmod 600 -R ${AWS_FOLDER}
 
+set +x
 # add the auth token in default.conf
 AUTH=$(grep  X-Forwarded-User $CONFIG | awk '{print $4}'| uniq|tr -d "\n\r")
 TOKEN=$(aws ecr get-login --no-include-email | awk '{print $6}')
 AUTH_N=$(echo AWS:${TOKEN}  | base64 |tr -d "[:space:]")
-sed -i "s|${AUTH%??}|${AUTH_N}|g" $CONFIG
+echo $AUTH_N > /usr/local/openresty/nginx/token.txt
 
+set -x
 # make sure cache directory has correct ownership
 chown -R nginx:nginx /cache
 


### PR DESCRIPTION
Sometimes the AWS ECR token is longer than the [NGX_CONF_BUFFER](https://github.com/nginx/nginx/blob/master/src/core/ngx_conf_file.c#L11) which is hard coded to 4096.
Example with my current token:
```
aws ecr get-login --no-include-email | awk '{print $6}' > token
wc -c token 
    4781 token
```

Therefore, using sed to replace the $http_authorization will cause this error :
```
2025-01-14T09:22:04.074351537Z nginx: [emerg] too long parameter, probably missing terminating """ character in /usr/local/openresty/nginx/conf/nginx.conf:70
```
Proposed workaround is to put the token in a file and store the token in a variable in memory.